### PR TITLE
Fix: Create db directory before connecting to SQLite database

### DIFF
--- a/database/src/database/sqlite_database.py
+++ b/database/src/database/sqlite_database.py
@@ -14,6 +14,11 @@ class SqliteDB(GameDB):
         file_name = f'{id}_{variant}'
         self.path = f'{Path(__file__).resolve().parents[2]}/db/{file_name}.db'
         self.exists = os.path.exists(self.path)
+        
+        # Create db directory if it doesn't exist and we're not in read-only mode
+        if not ro:
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        
         uri_path = self.path
         if ro:
             uri_path = f'file:{self.path}?immutable=1'


### PR DESCRIPTION
## Summary
Fixes issue where SqliteDB fails to initialize when the `db/` directory does not exist.

## Problem
After cloning the repository and running setup, attempting to solve a game throws:
```
sqlite3.OperationalError: unable to open database file
```

This occurs because the `/database/db/` directory is not created during project setup.

## Solution
- Added `os.makedirs(os.path.dirname(self.path), exist_ok=True)` before connecting to the database
- Only creates the directory when not in read-only mode (`ro=False`)
- This ensures the directory exists before SQLite attempts to create the database file

## Changes
- Modified `database/src/database/sqlite_database.py`
- Added directory creation in `__init__` method (lines 21-23)

## Testing
- Tested with a fresh clone of the repository
- Directory is created automatically when needed
- No errors when connecting to database for the first time

## Related Issue
Fixes #5

---
🤖 First-time contributor! Happy to help improve this project.