### PR TITLE
Solver change

### DIFF
--- a/database/db/.gitignore
+++ b/database/db/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file itself
+!.gitignore

--- a/games/README.md
+++ b/games/README.md
@@ -13,9 +13,9 @@ Required functions:
 * `to_string` : transform and return the given integer position into a string representation, based on the given mode.
 * `from_string` : transform and return the given `StringMode.Readable` position string into the integer representation.
 * `move_to_string` : transform and return the given integer move into a string representation, based on the given mode.
+* `hash_ext` : given a position, return a number representing the hash number of the position. If you decide not to implement this function, the default behavior is returning position. Therefore, position will have to be an integer. 
 
 Recommended functions:
-* `hash` : used to transform an internal, readable representation of a position into an integer in a reversible way. You can design this as you see fit. May be unnecessary for games/puzzles that have an obvious integer state representation (i.e. ten-to-zero).
-* `unhash` : reverse of hash.
+* `unhash_ext` : reverse of hash_ext. The default behavior is to return hashed position, which, by default, is just an integer. Refer to hash_ext for details on default behavior.
 
 Run `uv run solver <your_game_name>` to solve all variants, or add `-v <variant_name>` for specific variants. To overwrite an existing database and resolve, add `-o`.

--- a/games/src/games/pancakes.py
+++ b/games/src/games/pancakes.py
@@ -27,7 +27,7 @@ class Pancakes(Game):
         direction_choices = [0, 1]
         random.shuffle(widths)
         directions = [random.choice(direction_choices) for _ in range(self.height)]
-        return (widths, directions)
+        return self.hash(widths, directions)
     
     def generate_moves(self, position: int) -> list[int]:
         """
@@ -39,18 +39,18 @@ class Pancakes(Game):
         """
         Returns the resulting position of applying move to position.
         """
-        (widths, dirs) = position
+        (widths, dirs) = self.unhash(position)
         new_widths = widths[:]
         new_dirs = dirs[:]
         new_widths[move:] = reversed(widths[move:])
         new_dirs[move:] = [x ^ 0b1 for x in  reversed(dirs[move:])]
-        return (new_widths, new_dirs)
+        return self.hash(new_widths, new_dirs)
 
     def primitive(self, position) -> Optional[Value]:
         """
         Returns a Value enum which defines whether the current position is a win, loss, or non-terminal. 
         """
-        (widths, dirs) = position
+        (widths, dirs) = self.unhash(position)
         correct_order = widths == sorted(widths, reverse=True)
         correct_direction = all(x == 0 for x in dirs)
         if correct_order and correct_direction:
@@ -63,7 +63,7 @@ class Pancakes(Game):
         """
         pos_arr = []
         adder = ord('a') - 1
-        (widths, dirs) = position
+        (widths, dirs) = self.unhash(position)
         for i in range(self.height):
             val = str(widths[i]) if dirs[i] == 0 else chr(widths[i] + adder)
             pos_arr.append(val)
@@ -87,7 +87,7 @@ class Pancakes(Game):
             else:
                 dirs.append(0)
                 widths.append(int(char))
-        return (widths, dirs)
+        return self.hash(widths, dirs)
 
 
 
@@ -97,8 +97,7 @@ class Pancakes(Game):
         """
         return f'A_-_{move}_x'
 
-    def hash_ext(self, position) -> int:
-        (widths, directions) = position
+    def hash(self, widths, directions) -> int:
         h = 0
         n = self.height
         for i in range(n):
@@ -111,7 +110,7 @@ class Pancakes(Game):
         h = (h << n) | direction_hash
         return h
 
-    def unhash_ext(self, position) -> tuple[list[int]]:
+    def unhash(self, position) -> tuple[list[int]]:
         width_arr = []
         direction_arr = []
         n = self.height

--- a/solver/src/solver/solver.py
+++ b/solver/src/solver/solver.py
@@ -147,9 +147,3 @@ class Solver:
                 return Value.Win
             else:
                 return val
-
-    def get_remoteness(self, state: int) -> int:
-        rem, _ = self.db.get(state)
-        if rem is None:
-            return -1
-        return rem

--- a/solver/src/solver/solver.py
+++ b/solver/src/solver/solver.py
@@ -59,6 +59,7 @@ class Solver:
         q = deque()
         start = self.game.start()
 
+        no_hash = hasattr(self.game, "no_hash")
         hash_ext = self.game.hash_ext
         primitive = self.game.primitive
         do_move = self.game.do_move
@@ -66,7 +67,10 @@ class Solver:
         n_players = self.game.n_players
 
         q.appendleft(start)
-        visited.add(start)
+        if no_hash is None:
+            visited.add(hash_ext(start))
+        else:
+            visited.add(start)
         while q:
             position = q.popleft()
             hashed_position = hash_ext(position)
@@ -75,24 +79,20 @@ class Solver:
                 self.solution[hashed_position] = (REMOTENESS_TERMINAL, value)
                 self.unsolved_children[hashed_position] = 0
             else:
-                children = self.get_children(position, gen_moves, do_move)
-
-                unique_children = {hash_ext(c): c for c in children}
-                if self.unsolved_children.get(hashed_position, None) is None:
-                    self.unsolved_children[hashed_position] = 0
-                
-                if not unique_children and n_players == 1:
+                children = self.get_children(position, gen_moves, do_move)    
+                if not children and n_players == 1:
                     self.solution[hashed_position] = (REMOTENESS_TERMINAL, Value.Loss)
 
                 for child in children:
-                    if child not in visited:
-                        visited.add(child)
-                        q.append(child)
-
-                for hashed_child, child in unique_children.items():
+                    hashed_child = hash_ext(child)
+                    child_alt = hashed_child if no_hash is None else child
                     if hashed_child != hashed_position:
                         self.parent_map[hashed_child].append(hashed_position)
-                        self.unsolved_children[hashed_position] += 1
+                        prev_unsolved = self.unsolved_children.get(hashed_position, 0)
+                        self.unsolved_children[hashed_position] = prev_unsolved + 1
+                    if child_alt not in visited:
+                        visited.add(child_alt)
+                        q.append(child)
 
 
     def propagate(self):

--- a/solver/src/solver/solver.py
+++ b/solver/src/solver/solver.py
@@ -67,10 +67,10 @@ class Solver:
         n_players = self.game.n_players
 
         q.appendleft(start)
-        if no_hash is None:
-            visited.add(hash_ext(start))
-        else:
+        if no_hash:
             visited.add(start)
+        else:
+            visited.add(hash_ext(start))
         while q:
             position = q.popleft()
             hashed_position = hash_ext(position)
@@ -85,7 +85,7 @@ class Solver:
 
                 for child in children:
                     hashed_child = hash_ext(child)
-                    child_alt = hashed_child if no_hash is None else child
+                    child_alt = child if no_hash else hashed_child
                     if hashed_child != hashed_position:
                         self.parent_map[hashed_child].append(hashed_position)
                         prev_unsolved = self.unsolved_children.get(hashed_position, 0)

--- a/solver/src/solver/solver.py
+++ b/solver/src/solver/solver.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import deque, defaultdict
 from models import *
 from database import DuckDB, SqliteDB
 import time
@@ -10,7 +10,7 @@ class Solver:
     def __init__(self, game: Game):
         self._game = game
         self.solution = {}
-        self.parent_map = {}
+        self.parent_map = defaultdict(list)
         self.unsolved_children = {}
 
     def solve(self, overwrite=False, variant=None):
@@ -22,7 +22,7 @@ class Solver:
 
         for variant in variants:
             self.solution = {}
-            self.parent_map = {}
+            self.parent_map = defaultdict(list)
             self.unsolved_children = {}
             self.game = self._game(variant)
             self.db = SqliteDB(self._game.id, variant, ro=False)
@@ -49,99 +49,92 @@ class Solver:
             else:
                 print(f"{self.game.id}, variant: {variant} already solved.")
 
-    def get_children(self, position):
-        unhashed = self.game.unhash_ext(position)
-        moves = self.game.generate_moves(unhashed)
-        children = list(map(lambda m: self.game.hash_ext(self.game.do_move(unhashed, m)), moves))
+    def get_children(self, position, generate_moves, do_move):
+        moves = generate_moves(position)
+        children = list(map(lambda m: do_move(position, m), moves))
         return children
 
     def discover(self):
         visited = set()
         q = deque()
-        start = self.game.hash_ext(self.game.start())
-        q.appendleft(start)
-        visited.add(start)
-        while q:
-            position = q.pop()
-            value = self.game.primitive(self.game.unhash_ext(position))
-            if value is not None:
-                self.solution[position] = (REMOTENESS_TERMINAL, value)
-                self.unsolved_children[position] = 0
-            else:
-                children = self.get_children(position)
-                self.unsolved_children[position] = len(children)
-                if not children and self.game.n_players == 1:
-                    self.solution[position] = (REMOTENESS_TERMINAL, Value.Loss)
+        start = self.game.start()
 
-                for child in children:
-                    if not self.parent_map.get(child):
-                        self.parent_map[child] = set()
-                    self.parent_map[child].add(position)
-                    if child not in visited:
-                        visited.add(child)
-                        q.appendleft(child)
-    
+        hash_ext = self.game.hash_ext
+        primitive = self.game.primitive
+        do_move = self.game.do_move
+        gen_moves = self.game.generate_moves
+        n_players = self.game.n_players
+
+        q.appendleft(start)
+        visited.add(hash_ext(start))
+        while q:
+            position = q.popleft()
+            hashed_position = hash_ext(position)
+            value = primitive(position)
+            if value is not None:
+                self.solution[hashed_position] = (REMOTENESS_TERMINAL, value)
+                self.unsolved_children[hashed_position] = 0
+            else:
+                children = self.get_children(position, gen_moves, do_move)
+                unique_children = {hash_ext(c): c for c in children}
+                self.unsolved_children[hashed_position] = len(unique_children)
+                if not unique_children and n_players == 1:
+                    self.solution[hashed_position] = (REMOTENESS_TERMINAL, Value.Loss)
+
+                for hashed_child, child in unique_children.items():
+                    self.parent_map[hashed_child].append(hashed_position)
+                    
+                    if hashed_child not in visited:
+                        visited.add(hashed_child)
+                        q.append(child)
+
+
     def propagate(self):
         wins = deque()
         ties = deque()
         losses = deque()
+
         for pos, (_, val) in self.solution.items():
             match val:
-                case Value.Win: wins.appendleft(pos)
-                case Value.Tie: ties.appendleft(pos)
-                case Value.Loss: losses.appendleft(pos)
+                case Value.Win: wins.append(pos)
+                case Value.Tie: ties.append(pos)
+                case Value.Loss: losses.append(pos)
         while wins or ties or losses:
-            position = None
+            hashed_position = None
             if losses:
-                position = losses.pop()
+                hashed_position = losses.popleft()
             elif wins:
-                position = wins.pop()
+                hashed_position = wins.popleft()
             else:
-                position = ties.pop()
-            (curr_rem, curr_val) = self.solution.get(position)
+                hashed_position = ties.popleft()
+            (curr_rem, curr_val) = self.solution[hashed_position]
             parent_rem = curr_rem + 1
             parent_val: Value = self.parent_value(curr_val)
-            parents = self.parent_map.get(position, set())
-            for parent in parents:
-                unsolved_children = self.unsolved_children[parent]
+            parents = self.parent_map.get(hashed_position, [])
+            for hashed_parent in parents:
+                unsolved_children = self.unsolved_children[hashed_parent]
                 if unsolved_children == 0:
                     continue
                 if parent_val == Value.Loss:
-                    self.unsolved_children[parent] = unsolved_children - 1
+                    self.unsolved_children[hashed_parent] -= 1
                 else:
-                    self.unsolved_children[parent] = 0
-                ex_parent_sol = self.solution.get(parent)
-                if ex_parent_sol is None:
-                    self.solution[parent] = (parent_rem, parent_val)
-                else:
-                    (ex_parent_rem, ex_parent_val) = ex_parent_sol
-                    propagate = False
-                    if ex_parent_val < parent_val:
-                        propagate = True
-                    elif ex_parent_val == parent_val:
-                        if ex_parent_val == Value.Loss:
-                            if ex_parent_rem < parent_rem:
-                                propagate = True
-                        elif ex_parent_rem > parent_rem:
-                            propagate = True
-                    if propagate:
-                        self.solution[parent] = (parent_rem, parent_val)
-                if self.unsolved_children[parent] == 0:
-                    (_, p_val) = self.solution[parent]
-                    match p_val:
-                        case Value.Win: wins.appendleft(parent)
-                        case Value.Tie: ties.appendleft(parent)
-                        case Value.Loss: losses.appendleft(parent)
-                    
+                    self.unsolved_children[hashed_parent] = 0
+                
+                if self.unsolved_children[hashed_parent] == 0:
+                    self.solution[hashed_parent] = (parent_rem, parent_val)
+                    match parent_val:
+                        case Value.Win: wins.append(hashed_parent)
+                        case Value.Tie: ties.append(hashed_parent)
+                        case Value.Loss: losses.append(hashed_parent)
 
     def resolve_draws(self):
-        for pos in self.unsolved_children.keys():
+        for pos_hash in self.unsolved_children.keys():
             if self.game.n_players == 2:
-                if self.unsolved_children[pos] > 0:
-                    self.solution[pos] = (REMOTENESS_DRAW, Value.Draw)
+                if self.unsolved_children[pos_hash] > 0:
+                    self.solution[pos_hash] = (REMOTENESS_DRAW, Value.Draw)
             else:
-                if pos not in self.solution or self.unsolved_children[pos] > 0:
-                    self.solution[pos] = (REMOTENESS_DRAW, Value.Loss)
+                if pos_hash not in self.solution or self.unsolved_children[pos_hash] > 0:
+                    self.solution[pos_hash] = (REMOTENESS_DRAW, Value.Loss)
             
     
     def parent_value(self, val: Value) -> Value:
@@ -154,15 +147,7 @@ class Solver:
                 return Value.Win
             else:
                 return val
-    
-    def print(self):
-        if self.solution:
-            sol = [(position, rem, value) for position, (rem, value) in self.solution.items()]
-        else:
-            sol = self.db.get_all()
-        for (position, rem, value) in sol:
-            print(f'state: {self.game.to_string(position, StringMode.Readable)} | remoteness: {rem} | value: {Value(value).name}')
-    
+
     def get_remoteness(self, state: int) -> int:
         rem, _ = self.db.get(state)
         if rem is None:

--- a/solver/src/solver/solver.py
+++ b/solver/src/solver/solver.py
@@ -66,7 +66,7 @@ class Solver:
         n_players = self.game.n_players
 
         q.appendleft(start)
-        visited.add(hash_ext(start))
+        visited.add(start)
         while q:
             position = q.popleft()
             hashed_position = hash_ext(position)
@@ -76,17 +76,23 @@ class Solver:
                 self.unsolved_children[hashed_position] = 0
             else:
                 children = self.get_children(position, gen_moves, do_move)
+
                 unique_children = {hash_ext(c): c for c in children}
-                self.unsolved_children[hashed_position] = len(unique_children)
+                if self.unsolved_children.get(hashed_position, None) is None:
+                    self.unsolved_children[hashed_position] = 0
+                
                 if not unique_children and n_players == 1:
                     self.solution[hashed_position] = (REMOTENESS_TERMINAL, Value.Loss)
 
-                for hashed_child, child in unique_children.items():
-                    self.parent_map[hashed_child].append(hashed_position)
-                    
-                    if hashed_child not in visited:
-                        visited.add(hashed_child)
+                for child in children:
+                    if child not in visited:
+                        visited.add(child)
                         q.append(child)
+
+                for hashed_child, child in unique_children.items():
+                    if hashed_child != hashed_position:
+                        self.parent_map[hashed_child].append(hashed_position)
+                        self.unsolved_children[hashed_position] += 1
 
 
     def propagate(self):


### PR DESCRIPTION
Add support for puzzles where multiple "positions" map to a single hashed value: For example, a puzzle where the player's position does not change the value of the puzzle until they interact with the environment.